### PR TITLE
Parameter type annotations fix

### DIFF
--- a/src/skyciv/classes/model/components/area_loads/area_load.py
+++ b/src/skyciv/classes/model/components/area_loads/area_load.py
@@ -6,7 +6,7 @@ class AreaLoad:
     def __init__(self,
                  type: Literal["one_way", "two_way",
                                "column_wind_load", "open_structure"] = None,
-                 nodes: list[int] = None,
+                 nodes: 'list[int]' = None,
                  mag: float = None,
                  direction: Literal["X", "Y", "Z"] = None,
                  elevations: str = None,

--- a/src/skyciv/classes/model/components/area_loads/area_loads.py
+++ b/src/skyciv/classes/model/components/area_loads/area_loads.py
@@ -10,7 +10,7 @@ class AreaLoads(ModelCollectionComponent):
 
     def add(self,
             type: Literal["one_way", "two_way", "column_wind_load", "open_structure"],
-            nodes: list[int],
+            nodes: 'list[int]',
             mag: float,
             direction: Literal["X", "Y", "Z"],
             elevations: str = 0,
@@ -57,7 +57,7 @@ class AreaLoads(ModelCollectionComponent):
 
         return next_index
 
-    def get_area_load_ids_from_node_ids(self, nodes: list[int]) -> list[int]:
+    def get_area_load_ids_from_node_ids(self, nodes: 'list[int]') -> 'list[int]':
         """Get the IDs of all area loads that match the provided nodes array. Node order IS considered.
 
         Args:

--- a/src/skyciv/classes/model/components/members/members.py
+++ b/src/skyciv/classes/model/components/members/members.py
@@ -52,7 +52,7 @@ class Members(ModelCollectionComponent):
         setattr(self, str(next_index), member)
         return next_index
 
-    def get_member_ids_from_nodes_ids(self, node_A: int, node_B: int) -> list[int]:
+    def get_member_ids_from_nodes_ids(self, node_A: int, node_B: int) -> 'list[int]':
         """Get the IDs of all members by its end nodes.
 
         Args:

--- a/src/skyciv/classes/model/components/meshed_plates/meshed_plates.py
+++ b/src/skyciv/classes/model/components/meshed_plates/meshed_plates.py
@@ -32,7 +32,7 @@ class MeshedPlates(ModelCollectionComponent):
         setattr(self, str(next_index), mp)
         return next_index
 
-    def get_meshed_plate_ids_from_nodes_ids(self, node_A: int, node_B: int, node_C: int, node_D: int = None) -> list[int]:
+    def get_meshed_plate_ids_from_nodes_ids(self, node_A: int, node_B: int, node_C: int, node_D: int = None) -> 'list[int]':
         """Get the IDs of all meshed plates by corner nodes.
 
         Args:

--- a/src/skyciv/classes/model/components/plates/plate.py
+++ b/src/skyciv/classes/model/components/plates/plate.py
@@ -4,7 +4,7 @@ from typing import Literal
 class Plate:
     def __init__(
         self,
-        nodes: list[int] = None,
+        nodes: 'list[int]' = None,
         thickness: float = None,
         material_id: int = None,
         rotZ: float = 0,
@@ -15,7 +15,7 @@ class Plate:
         shear_thickness: float = None,
         bending_thickness: float = None,
         state: Literal["stress", "strain"] = 'stress',
-        holes: list[int] = None,
+        holes: 'list[int]' = None,
         is_meshed: bool = False
     ) -> None:
         """Creates an instance of the SkyCiv Plate class.

--- a/src/skyciv/classes/model/components/plates/plates.py
+++ b/src/skyciv/classes/model/components/plates/plates.py
@@ -9,7 +9,7 @@ class Plates(ModelCollectionComponent):
     """
 
     def add(self,
-            nodes: list[int] = None,
+            nodes: 'list[int]' = None,
             thickness: float = None,
             material_id: int = None,
             rotZ: float = 0,
@@ -20,7 +20,7 @@ class Plates(ModelCollectionComponent):
             shear_thickness: float = None,
             bending_thickness: float = None,
             state: Literal["stress", "strain"] = 'stress',
-            holes: list[int] = None,
+            holes: 'list[int]' = None,
             is_meshed: bool = False
             ) -> int:
         """Create a plate with the next available ID.
@@ -67,7 +67,7 @@ class Plates(ModelCollectionComponent):
 
         return next_index
 
-    def get_plate_ids_from_node_ids(self, nodes: list[int]) -> list[int]:
+    def get_plate_ids_from_node_ids(self, nodes: 'list[int]') -> 'list[int]':
         """Get the IDs of all plates that match the provided nodes array. Node order IS considered.
 
         Args:

--- a/src/skyciv/classes/model/components/sections/section.py
+++ b/src/skyciv/classes/model/components/sections/section.py
@@ -6,7 +6,7 @@ class Section:
         for key in self.__dict__.keys():
             del self[key]
 
-    def load_section_from_library(self, path: list[str], material_id: int) -> None:
+    def load_section_from_library(self, path: 'list[str]', material_id: int) -> None:
         """Set the section from the SkyCiv section library.
 
         Args:

--- a/src/skyciv/classes/model/components/sections/sections.py
+++ b/src/skyciv/classes/model/components/sections/sections.py
@@ -7,7 +7,7 @@ class Sections(ModelCollectionComponent):
     """Creates an instance of the SkyCiv Sections class.
     """
 
-    def add_library_section(self, path: list[str], material_id: int) -> int:
+    def add_library_section(self, path: 'list[str]', material_id: int) -> int:
         """Add a section from the SkyCiv section library.
 
         Args:
@@ -43,7 +43,7 @@ class Sections(ModelCollectionComponent):
         setattr(self, str(next_index), new_section)
         return next_index
 
-    def ids_from_path(self, path: list[str]) -> list[int]:
+    def ids_from_path(self, path: 'list[str]') -> 'list[int]':
         """Get all sections that match a SkyCiv section library path.
 
         Args:

--- a/src/skyciv/utils/helpers.py
+++ b/src/skyciv/utils/helpers.py
@@ -50,7 +50,7 @@ def has_get_method(dict: dict) -> bool:
     return False
 
 
-def keyvals(obj: dict) -> list[list]:
+def keyvals(obj: dict) -> 'list[list]':
     """Return the key value pairs of a class or dictionary.
     Args:
         obj (dict): A class or dictionary.
@@ -65,7 +65,7 @@ def keyvals(obj: dict) -> list[list]:
         return vars(obj).items()
 
 
-def keys(obj: dict) -> list[list]:
+def keys(obj: dict) -> 'list[list]':
     """Return the keys of a class or dictionary.
     Args:
         obj (dict): A class or dictionary.


### PR DESCRIPTION
Hi SkyCiv Team! 

We just started playing around with the python package for the API and noticed that we were getting a runtime exception of:

`TypeError: 'type' object is not subscriptable`

After digging a little bit we were able to fix this exception by updating the type annotations for various function parameters (Mostly they were ones that were annotating list[x]). All it required was surrounding the annotations in single-quotes. I went ahead and forked your project and performed this fix for us but wanted to put a PR here too if this is something that you guys would also like to look into. 

Let me know if you have any other questions or if this was something we could have resolved another way on our end. 

Thanks!
 